### PR TITLE
change psycopg2 to psycopg2-binary packange

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==4.1.4
 gunicorn==20.1.0
 whitenoise==6.2.0
 
-psycopg2==2.9.5
+psycopg2-binary==2.9.5
 
 redis==4.4.0
 celery==5.2.7


### PR DESCRIPTION
Problem: Whenever I install packages from the requirements.txt file, it shows the error.
Solution: After Changing the psycopg2 to psycopg2-binary the problem is fixed.
OS: Mac
    
    ~$ pip3 install -r requirements.txt 
    Collecting Django==4.1.4
      Using cached Django-4.1.4-py3-none-any.whl (8.1 MB)
    Collecting gunicorn==20.1.0
      Using cached gunicorn-20.1.0-py3-none-any.whl (79 kB)
    Collecting whitenoise==6.2.0
      Using cached whitenoise-6.2.0-py3-none-any.whl (19 kB)
    Collecting psycopg2==2.9.5
      Using cached psycopg2-2.9.5.tar.gz (384 kB)
      Preparing metadata (setup.py) ... error
      error: subprocess-exited-with-error
      
      × python setup.py egg_info did not run successfully.
      │ exit code: 1
      ╰─> [25 lines of output]
          /Volumes/Work/projects/the_nerdy_nation/the-nerdynation-backend/venv/lib/python3.10/site-packages/setuptools/config/setupcfg.py:463: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
            warnings.warn(msg, warning_class)
          running egg_info
          creating /private/var/folders/fd/hwf9y7m97cjc9429tz4b9hlr0000gn/T/pip-pip-egg-info-cq_2dx8u/psycopg2.egg-info
          writing /private/var/folders/fd/hwf9y7m97cjc9429tz4b9hlr0000gn/T/pip-pip-egg-info-cq_2dx8u/psycopg2.egg-info/PKG-INFO
          writing dependency_links to /private/var/folders/fd/hwf9y7m97cjc9429tz4b9hlr0000gn/T/pip-pip-egg-info-cq_2dx8u/psycopg2.egg-info/dependency_links.txt
          writing top-level names to /private/var/folders/fd/hwf9y7m97cjc9429tz4b9hlr0000gn/T/pip-pip-egg-info-cq_2dx8u/psycopg2.egg-info/top_level.txt
          writing manifest file '/private/var/folders/fd/hwf9y7m97cjc9429tz4b9hlr0000gn/T/pip-pip-egg-info-cq_2dx8u/psycopg2.egg-info/SOURCES.txt'
      
      Error: pg_config executable not found.
      
      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:
      
          python setup.py build_ext --pg-config /path/to/pg_config build ...
      
      or with the pg_config option in 'setup.cfg'.
      
      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.
      
      For further information please check the 'doc/src/install.rst' file (also at
      <https://www.psycopg.org/docs/install.html>).
      
      [end of output]
  
      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: metadata-generation-failed
    
    × Encountered error while generating package metadata.
    ╰─> See above for output.
    
    note: This is an issue with the package mentioned above, not pip.
    hint: See above for details.
    
    [notice] A new release of pip available: 22.2.2 -> 22.3.1
    [notice] To update, run: pip install --upgrade pip