### PR TITLE
Add configurable timeout for gunicorn workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,9 @@ export WEB_CONCURRENCY=1
 #export WEB_RELOAD=false
 export WEB_RELOAD=true
 
+# Configure the timeout value in seconds for gunicorn.
+#export WEB_TIMEOUT=120
+
 # You'll always want to set POSTGRES_USER and POSTGRES_PASSWORD since the
 # postgres Docker image uses them for its default database user and password.
 export POSTGRES_USER=hello

--- a/src/config/gunicorn.py
+++ b/src/config/gunicorn.py
@@ -12,3 +12,5 @@ workers = int(os.getenv("WEB_CONCURRENCY", multiprocessing.cpu_count() * 2))
 threads = int(os.getenv("PYTHON_MAX_THREADS", 1))
 
 reload = bool(strtobool(os.getenv("WEB_RELOAD", "false")))
+
+timeout = int(os.getenv("WEB_TIMEOUT", 120))


### PR DESCRIPTION
I added `timeout` setting to gunicorn config which is configurable via environment variable.